### PR TITLE
Clamp exec output budgets

### DIFF
--- a/codex-rs/core/tests/suite/exec.rs
+++ b/codex-rs/core/tests/suite/exec.rs
@@ -57,6 +57,7 @@ async fn exit_code_0_succeeds() {
     assert_eq!(output.stdout.text, "hello\n");
     assert_eq!(output.stderr.text, "");
     assert_eq!(output.stdout.truncated_after_lines, None);
+    assert!(!output.stdout.truncated_by_bytes);
 }
 
 /// Command succeeds with exit code 0 normally
@@ -77,6 +78,7 @@ async fn truncates_output_lines() {
         .join("");
     assert_eq!(output.stdout.text, expected_output);
     assert_eq!(output.stdout.truncated_after_lines, None);
+    assert!(!output.stdout.truncated_by_bytes);
 }
 
 /// Command succeeds with exit code 0 normally
@@ -92,8 +94,22 @@ async fn truncates_output_bytes() {
 
     let output = run_test_cmd(tmp, cmd).await.unwrap();
 
-    assert!(output.stdout.text.len() >= 15000);
+    assert!(output.stdout.truncated_by_bytes);
     assert_eq!(output.stdout.truncated_after_lines, None);
+    assert!(
+        output.stdout.text.contains("output truncated to 6 KiB"),
+        "missing truncation notice: {}",
+        output.stdout.text
+    );
+    assert!(output.aggregated_output.truncated_by_bytes);
+    assert!(
+        output
+            .aggregated_output
+            .text
+            .contains("output truncated to 6 KiB"),
+        "missing aggregated truncation notice: {}",
+        output.aggregated_output.text
+    );
 }
 
 /// Command not found returns exit code 127, this is not considered a sandbox error

--- a/codex-rs/core/tests/suite/exec_stream_events.rs
+++ b/codex-rs/core/tests/suite/exec_stream_events.rs
@@ -78,6 +78,7 @@ async fn test_exec_stdout_stream_events_echo() {
 
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout.text, "hello-world\n");
+    assert!(!result.stdout.truncated_by_bytes);
 
     let streamed = collect_stdout_events(rx);
     // We should have received at least the same contents (possibly in one chunk)
@@ -131,6 +132,7 @@ async fn test_exec_stderr_stream_events_echo() {
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout.text, "");
     assert_eq!(result.stderr.text, "oops\n");
+    assert!(!result.stderr.truncated_by_bytes);
 
     // Collect only stderr delta events
     let mut err = Vec::new();
@@ -184,6 +186,7 @@ async fn test_aggregated_output_interleaves_in_order() {
     assert_eq!(result.stderr.text, "E1\nE2\n");
     assert_eq!(result.aggregated_output.text, "O1\nE1\nO2\nE2\n");
     assert_eq!(result.aggregated_output.truncated_after_lines, None);
+    assert!(!result.aggregated_output.truncated_by_bytes);
 }
 
 #[tokio::test]
@@ -224,6 +227,9 @@ async fn test_exec_timeout_returns_partial_output() {
     assert_eq!(output.stdout.text, "before\n");
     assert!(output.stderr.text.is_empty());
     assert_eq!(output.aggregated_output.text, "before\n");
+    assert!(!output.stdout.truncated_by_bytes);
+    assert!(!output.stderr.truncated_by_bytes);
+    assert!(!output.aggregated_output.truncated_by_bytes);
     assert!(output.duration >= Duration::from_millis(200));
     assert!(output.timed_out);
 }


### PR DESCRIPTION
## Summary
- enforce 6 KiB generic and 8 KiB `rg` output caps in the exec pipeline with truncation notices
- propagate byte-truncation metadata through exec results and extend the unit tests
- record the new guardrail status in KSP-PLAN.md

## Testing
- cargo test -p codex-core tests:: -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68da32b80d648323b673f16decb57475